### PR TITLE
Fixing error where float was expected, but got int16

### DIFF
--- a/whisper_ros/whisper_ros/silero_vad_node.py
+++ b/whisper_ros/whisper_ros/silero_vad_node.py
@@ -37,6 +37,15 @@ from audio_common.utils import msg_to_array
 from audio_common_msgs.msg import AudioStamped
 
 
+def int2float(sound):
+    abs_max = np.abs(sound).max()
+    sound = sound.astype('float32')
+    if abs_max > 0:
+        sound *= 1/32768
+    sound = sound.squeeze()  # depends on the use case
+    return sound
+
+
 class SileroVadNode(Node):
 
     def __init__(self) -> None:
@@ -66,7 +75,7 @@ class SileroVadNode(Node):
         if not self.enabled:
             return
 
-        audio = msg_to_array(msg.audio.audio_data, msg.audio.info.format)
+        audio = int2float(msg_to_array(msg.audio.audio_data, msg.audio.info.format))
         if audio is None:
             self.get_logger().error(f"Format {msg.audio.info.format} unknown")
             return


### PR DESCRIPTION
I was getting an error with silero vad until I added this. I'm on Ubuntu 22.04 with cuda 12.4. I found the fix here:
https://github.com/snakers4/silero-vad/blob/master/examples/pyaudio-streaming/pyaudio-streaming-examples.ipynb